### PR TITLE
Removed Spite, as it is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This project is a fork of [Asset Ripper](https://github.com/AssetRipper/AssetRipper), specialized for creating level editors for ULTRAKILL.
 
 Useful resources:
-- [Rude wiki](https://coolboi21.github.io/Rude-Docs/#/Home)
-- [E&S wiki](https://layzyidiot.github.io/e-sw/#/)
+- [ULTRAMapping Docs](https://envy-spite-team.github.io/ULTRAMappingDocs/)
+- [Rude wiki(Outdated)](https://coolboi21.github.io/Rude-Docs/#/Home)
 
 # Legal Disclaimers
 

--- a/Source/AssetRipper.Export.UnityProjects/Project/CopyBaseProject.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Project/CopyBaseProject.cs
@@ -17,9 +17,6 @@ namespace AssetRipper.Export.UnityProjects.Project
 		private static string RUDE_PROJECT_PATH = "Resources/BaseRudeProject.zip";
 		private static string RUDE_PROJECT_URL = "https://raw.githubusercontent.com/eternalUnion/VanityReprised/master/BaseProjects/BaseRudeProject.zip";
 
-		private static string SPITE_PROJECT_PATH = "Resources/BaseSpiteProject.zip";
-		private static string SPITE_PROJECT_URL = "https://raw.githubusercontent.com/eternalUnion/VanityReprised/master/BaseProjects/BaseSpiteProject.zip";
-
 		private static Stream? GetFileFromUrl(string url)
 		{
 			using (var client = new HttpClient())
@@ -60,21 +57,8 @@ namespace AssetRipper.Export.UnityProjects.Project
 				}
 			}
 
-			string baseProjectPath;
-			string baseProjectUrl;
-			switch (GameData.ProjectToExport)
-			{
-				default:
-				case GameData.BaseProject.Rude:
-					baseProjectPath = RUDE_PROJECT_PATH;
-					baseProjectUrl = RUDE_PROJECT_URL;
-					break;
-
-				case GameData.BaseProject.Spite:
-					baseProjectPath = SPITE_PROJECT_PATH;
-					baseProjectUrl = SPITE_PROJECT_URL;
-					break;
-			}
+			string baseProjectPath = RUDE_PROJECT_PATH;
+			string baseProjectUrl = RUDE_PROJECT_URL;
 
 			// Try downloading from internet, fallback to local base project
 			/*Logger.Info("Downloading latest base project from the internet...");

--- a/Source/AssetRipper.GUI.Free/AssetRipper.GUI.Free.csproj
+++ b/Source/AssetRipper.GUI.Free/AssetRipper.GUI.Free.csproj
@@ -29,9 +29,6 @@
 	  <None Update="Resources\BaseRudeProject.zip">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>
-	  <None Update="Resources\BaseSpiteProject.zip">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </None>
 	</ItemGroup>
 	
 </Project>

--- a/Source/AssetRipper.GUI.Web/GameFileLoader.cs
+++ b/Source/AssetRipper.GUI.Web/GameFileLoader.cs
@@ -56,18 +56,7 @@ public static class GameFileLoader
 		if (IsLoaded)
 		{
 			// Change behavior, create folder inside the selected folder instead of deleting the selected folder
-			string originalName;
-			switch (GameData.ProjectToExport)
-			{
-				default:
-				case GameData.BaseProject.Rude:
-					originalName = "Rude";
-					break;
-
-				case GameData.BaseProject.Spite:
-					originalName = "Spite";
-					break;
-			}
+			string originalName = "Rude";
 
 			string folderName = originalName;
 			int i = 0;

--- a/Source/AssetRipper.GUI.Web/Pages/IndexPage.cs
+++ b/Source/AssetRipper.GUI.Web/Pages/IndexPage.cs
@@ -52,7 +52,6 @@ public sealed class IndexPage : DefaultPage
 				using (new Div(writer).WithClass("d-flex justify-content-center").End())
 				{
 					WriteGetLink(writer, "/ExportRude", "Generate RUDE project", "btn btn-success m-1");
-					WriteGetLink(writer, "/ExportSpite", "Generate SPITE project", "btn btn-success m-1");
 					WritePostLink(writer, "/Reset", Localization.MenuFileReset, "btn btn-danger m-1");
 				}
 			}

--- a/Source/AssetRipper.GUI.Web/WebApplicationLauncher.cs
+++ b/Source/AssetRipper.GUI.Web/WebApplicationLauncher.cs
@@ -131,11 +131,6 @@ public static class WebApplicationLauncher
 			GameData.ProjectToExport = GameData.BaseProject.Rude;
 			return Results.Redirect("/Commands");
 		});
-		app.MapGet("/ExportSpite", static () =>
-		{
-			GameData.ProjectToExport = GameData.BaseProject.Spite;
-			return Results.Redirect("/Commands");
-		});
 		app.MapGet("/Commands", CommandsPage.Instance.ToResult);
 		app.MapGet("/Privacy", PrivacyPage.Instance.ToResult);
 		app.MapGet("/Licenses", LicensesPage.Instance.ToResult);

--- a/Source/AssetRipper.Processing/GameData.cs
+++ b/Source/AssetRipper.Processing/GameData.cs
@@ -19,7 +19,6 @@ public record GameData(
 	public enum BaseProject
 	{
 		Rude,
-		Spite,
 	}
 	public static BaseProject ProjectToExport;
 


### PR DESCRIPTION
Removed the base project and the option to generate Spite project because of the fact that it is no longer maintained and will become unusable in the next ULTRAKILL update. As well as updated the resources in README.